### PR TITLE
Change request handling to use split instead of regular expressions.

### DIFF
--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -26,7 +26,6 @@ except ImportError:
 
 from errno import EAGAIN, ECONNRESET
 import os
-import re
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_HTTPServer.git"
@@ -60,8 +59,6 @@ HTTPStatus.INTERNAL_SERVER_ERROR = HTTPStatus(500, "Internal Server Error")
 
 
 class _HTTPRequest:
-    _REQUEST_RE = re.compile(r"(\S+)\s+(\S+)\s")
-
     def __init__(
         self, path: str = "", method: str = "", raw_request: bytes = None
     ) -> None:
@@ -70,12 +67,12 @@ class _HTTPRequest:
             self.method = method
         else:
             # Parse request data from raw request
-            match = self._REQUEST_RE.match(raw_request.decode("utf8"))
-            if match:
-                self.path = match.group(2)
-                self.method = match.group(1)
-            else:
-                raise ValueError("Unparseable raw_request:", raw_request)
+            request_text = raw_request.decode('utf8')
+            first_line = request_text[:request_text.find('\n')]
+            try:
+                (self.method, self.path, _httpversion) = first_line.split()
+            except ValueError:
+                raise ValueError("Unparseable raw_request: ", raw_request)
 
     def __hash__(self) -> int:
         return hash(self.method) ^ hash(self.path)

--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -67,12 +67,12 @@ class _HTTPRequest:
             self.method = method
         else:
             # Parse request data from raw request
-            request_text = raw_request.decode('utf8')
-            first_line = request_text[:request_text.find('\n')]
+            request_text = raw_request.decode("utf8")
+            first_line = request_text[: request_text.find("\n")]
             try:
                 (self.method, self.path, _httpversion) = first_line.split()
-            except ValueError:
-                raise ValueError("Unparseable raw_request: ", raw_request)
+            except ValueError as exc:
+                raise ValueError("Unparseable raw_request: ", raw_request) from exc
 
     def __hash__(self) -> int:
         return hash(self.method) ^ hash(self.path)


### PR DESCRIPTION
The regular expression fails with a stack overflow for paths of
more than 135 characters. The split also appears to be much faster.

Failing parse:

```python
>>> import re
>>> _REQUEST_RE = re.compile(r"(\S+)\s+(\S+)\s")
>>> _REQUEST_RE.match("GET /" + ("a" * 135) + " whatev")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: maximum recursion depth exceeded
```

Co-authored-by: Shae Erisson <shae@scannedinavian.com>