### PR TITLE
Split serve_forever to allow polling in loop and add another example with polling in while loop.

### DIFF
--- a/examples/httpserve_simplepolling.py
+++ b/examples/httpserve_simplepolling.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+from secrets import secrets  # pylint: disable=no-name-in-module
+
+import socketpool
+import wifi
+
+from adafruit_httpserver import HTTPServer, HTTPResponse
+
+ssid = secrets["ssid"]
+print("Connecting to", ssid)
+wifi.radio.connect(ssid, secrets["password"])
+print("Connected to", ssid)
+print(f"Listening on http://{wifi.radio.ipv4_address}:80")
+
+pool = socketpool.SocketPool(wifi.radio)
+server = HTTPServer(pool)
+
+
+@server.route("/")
+def base(request):  # pylint: disable=unused-argument
+    """Default reponse is /index.html"""
+    return HTTPResponse(filename="/index.html")
+
+
+# startup the server
+server.start(str(wifi.radio.ipv4_address))
+
+while True:
+    try:
+        # processing any waiting requests
+        server.poll()
+    except OSError:
+        continue


### PR DESCRIPTION
I split out the logic from the serve_forever into two methods start() and poll().   This will allow developers to do other work in the while loop while still processing the web requests. The original method now calls these two methods so that any existing code will still work.   Tested it using both of the existing examples and added a third that implements the start() and poll() functions.