### PR TITLE
Add buffer size property

### DIFF
--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -174,7 +174,7 @@ class MIMEType:
 
 
 class HTTPResponse:
-    """Details of an HTTP response. Use in @`HTTPServer.route` decorator functions."""
+    """Details of an HTTP response. Use in `HTTPServer.route` decorator functions."""
 
     _HEADERS_FORMAT = (
         "HTTP/1.1 {}\r\n"
@@ -365,8 +365,8 @@ class HTTPServer:
     @property
     def requestbuffersize(self) -> int:
         """
-        The maximum size of the incoming request buffer. If the default size isn't 
-        adequate to handle your incoming data you can set this after creating the 
+        The maximum size of the incoming request buffer. If the default size isn't
+        adequate to handle your incoming data you can set this after creating the
         server instance.
 
         Default size is 1024 bytes.

--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -361,3 +361,25 @@ class HTTPServer:
                 # connection reset by peer, try again later.
                 return
             raise
+
+    @property
+    def requestbuffersize(self) -> int:
+        """
+        The maximum size of the incoming request buffer. If the default size isn't 
+        adequate to handle your incoming data you can set this after creating the 
+        server instance.
+
+        Default size is 1024 bytes.
+
+        Example::
+
+            server = HTTPServer(pool)
+            server.requestbuffersize = 2048
+
+            server.serve_forever(str(wifi.radio.ipv4_address))
+        """
+        return len(self._buffer)
+
+    @requestbuffersize.setter
+    def requestbuffersize(self, value: int) -> None:
+        self._buffer = bytearray(value)

--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -363,7 +363,7 @@ class HTTPServer:
             raise
 
     @property
-    def requestbuffersize(self) -> int:
+    def request_buffer_size(self) -> int:
         """
         The maximum size of the incoming request buffer. If the default size isn't
         adequate to handle your incoming data you can set this after creating the
@@ -380,6 +380,6 @@ class HTTPServer:
         """
         return len(self._buffer)
 
-    @requestbuffersize.setter
-    def requestbuffersize(self, value: int) -> None:
+    @request_buffer_size.setter
+    def request_buffer_size(self, value: int) -> None:
         self._buffer = bytearray(value)

--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -374,7 +374,7 @@ class HTTPServer:
         Example::
 
             server = HTTPServer(pool)
-            server.requestbuffersize = 2048
+            server.request_buffer_size = 2048
 
             server.serve_forever(str(wifi.radio.ipv4_address))
         """

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,22 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/httpserver_simpletest.py
     :caption: examples/httpserver_simpletest.py
     :linenos:
+
+Temperature test
+--------------------
+
+Send the microcontroller temperature back to the browser with this simple test.
+
+.. literalinclude:: ../examples/httpserver_temperature.py
+    :caption: examples/httpserver_temperature.py
+    :linenos:
+
+Simple polling test
+-------------------
+
+If you want your code to do more than just serve web pages,
+use the start/poll methods as shown in this example.
+
+.. literalinclude:: ../examples/httpserver_simplepolling.py
+    :caption: examples/httpserver_simplepolling.py
+    :linenos:

--- a/examples/httpserver_simplepolling.py
+++ b/examples/httpserver_simplepolling.py
@@ -30,8 +30,11 @@ server.start(str(wifi.radio.ipv4_address))
 
 while True:
     try:
-        # do something useful in this section
-        # processing any waiting requests
+        # do something useful in this section,
+        # for example read a sensor and capture an average,
+        # or a running total of the last 10 samples
+
+        # process any waiting requests
         server.poll()
     except OSError:
         continue

--- a/examples/httpserver_simplepolling.py
+++ b/examples/httpserver_simplepolling.py
@@ -30,6 +30,7 @@ server.start(str(wifi.radio.ipv4_address))
 
 while True:
     try:
+        # do something useful in this section
         # processing any waiting requests
         server.poll()
     except OSError:


### PR DESCRIPTION
Add a property with getter/setter to the HTTPServer class to allow adjustment of the incoming buffer size.   Developers can use this to read or change the size of the buffer used to store the incoming request data.  This is especially useful when the incoming request is larger than the default buffer size.  Without this change any incoming data over the default buffer size (1024 bytes) would be truncated.

Also made some adjustments to the documentation.  Adding sections for the temperature and polling examples, fixing an auto generated link and add helpful comment to the polling example.

This PR will close #5  