### PR TITLE
enable user to access body of request

### DIFF
--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -289,7 +289,7 @@ class HTTPServer:
             @server.route(path, method)
             def route_func(request):
                 raw_text = request.raw_request.decode("utf8")
-                print("Received a request of length", len(raw_test), "bytes")
+                print("Received a request of length", len(raw_text), "bytes")
                 return HTTPResponse(body="hello world")
 
         """

--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -62,6 +62,7 @@ class _HTTPRequest:
     def __init__(
         self, path: str = "", method: str = "", raw_request: bytes = None
     ) -> None:
+        self.raw_request = raw_request
         if raw_request is None:
             self.path = path
             self.method = method
@@ -287,7 +288,10 @@ class HTTPServer:
 
             @server.route(path, method)
             def route_func(request):
+                raw_text = request.raw_request.decode("utf8")
+                print("Received a request of length", len(raw_test), "bytes")
                 return HTTPResponse(body="hello world")
+
         """
 
         def route_decorator(func: Callable) -> Callable:


### PR DESCRIPTION
Unless I'm mistaken, there doesn't appear to be a way to retrieve the content of an incoming request. This PR exposes the `raw_request` variable in the HTTPRequest object. I added a very basic usage example.