### PR TITLE
smaller buffer size for file read to send as HTTPResponse.

### DIFF
--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -244,7 +244,7 @@ class HTTPResponse:
             ),
         )
         with open(root + filename, "rb") as file:
-            while bytes_read := file.read(8192):
+            while bytes_read := file.read(2048):
                 self._send_bytes(conn, bytes_read)
 
     def _send_bytes(self, conn, buf):  # pylint: disable=no-self-use


### PR DESCRIPTION
This lowers the buffer size that files are read into for sending as HTTPResponse down to `2048` bytes which puts it under a limit that is affecting raspberry pi pico w [#7077](https://github.com/adafruit/circuitpython/issues/7077) for details.

This change allows responses larger than 2920 bytes to be returned successfully. Tested successfully up to `5408` bytes. 

Interestingly this change also seems to make the response come back quicker as well. With currently released version I am/was getting 300-500ms fairly consistently for the response times. With the version from this PR it's been more 100-150 with a few dipping below 100ms even.