### PR TITLE
Explicitly set accepted socket to blocking

### DIFF
--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -342,6 +342,7 @@ class HTTPServer:
         try:
             conn, _ = self._sock.accept()
             with conn:
+                conn.setblocking(True)
                 length, _ = conn.recvfrom_into(self._buffer)
 
                 request = _HTTPRequest(raw_request=self._buffer[:length])


### PR DESCRIPTION
The Python documentation states that otherwise, the blocking status of the newly accepted socket is implementation-defined:

> if the listening socket is in non-blocking mode, whether the socket returned by accept() is in blocking or non-blocking mode is operating system-dependent. If you want to ensure cross-platform behaviour, it is recommended you manually override this setting. <https://docs.python.org/3/library/socket.html#socket-timeouts>

When the connected socket is non-blocking (as it is on picow), the http library works erratically, depending whether the request has already arrived by the time recvfrom_into call occurs.

Closes: adafruit/circuitpython#7086