### PR TITLE
Change method to static method

### DIFF
--- a/adafruit_httpserver.py
+++ b/adafruit_httpserver.py
@@ -247,7 +247,8 @@ class HTTPResponse:
             while bytes_read := file.read(2048):
                 self._send_bytes(conn, bytes_read)
 
-    def _send_bytes(self, conn, buf):
+    @staticmethod
+    def _send_bytes(conn, buf):
         bytes_sent = 0
         bytes_to_send = len(buf)
         view = memoryview(buf)


### PR DESCRIPTION
Fixes the following CI errors:

```
black....................................................................Passed
reuse....................................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
Error: pylint (library code)....................................................Failed
- hook id: pylint
- exit code: 8

************* Module adafruit_httpserver
Error: adafruit_httpserver.py:250:4: R6301: Method could be a function (no-self-use)

-----------------------------------
Your code has been rated at 9.92/10

pylint (example code)....................................................Passed
pylint (test code)...................................(no files to check)Skipped
Error: Process completed with exit code 1.
```

