### PR TITLE
Buffer_size improvements

### DIFF
--- a/adafruit_httpserver/response.py
+++ b/adafruit_httpserver/response.py
@@ -171,10 +171,12 @@ class HTTPResponse:
         self,
         filename: str = "index.html",
         root_path: str = "./",
+        buffer_size: int = 1024,
     ) -> None:
         """
         Send response with content of ``filename`` located in ``root_path``.
         Implicitly calls ``_send_headers`` before sending the file content.
+        File is send split into ``buffer_size`` parts.
 
         Should be called **only once** per response.
         """
@@ -196,7 +198,7 @@ class HTTPResponse:
         )
 
         with open(root_path + filename, "rb") as file:
-            while bytes_read := file.read(2048):
+            while bytes_read := file.read(buffer_size):
                 self._send_bytes(self.request.connection, bytes_read)
         self._response_already_sent = True
 

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -172,6 +172,7 @@ class HTTPServer:
                     HTTPResponse(request).send_file(
                         filename=request.path,
                         root_path=self.root_path,
+                        buffer_size=self.request_buffer_size,
                     )
                 else:
                     HTTPResponse(


### PR DESCRIPTION
- Expose `buffer_size` in `response.send_file`
- Adjust default in `response` to match the one in `server`
- Use server's `buffer_size` when auto-serving files.

WIth current architecture I don't see an easy way to bound `response.send_file`'s buffer size to the one that exists in `server`.
