### PR TITLE
for RESTful API

### DIFF
--- a/adafruit_httpserver/route.py
+++ b/adafruit_httpserver/route.py
@@ -22,6 +22,9 @@ class _HTTPRoute:
         return hash(self.method) ^ hash(self.path)
 
     def __eq__(self, other: "_HTTPRoute") -> bool:
+        if self.path[-1] == '*':
+            str = self.path[0:len(self.path)-1]
+            return self.method == other.method and other.path.startswith(str)
         return self.method == other.method and self.path == other.path
 
     def __repr__(self) -> str:

--- a/adafruit_httpserver/route.py
+++ b/adafruit_httpserver/route.py
@@ -23,8 +23,8 @@ class _HTTPRoute:
 
     def __eq__(self, other: "_HTTPRoute") -> bool:
         if self.path[-1] == '*':
-            str = self.path[0:len(self.path)-1]
-            return self.method == other.method and other.path.startswith(str)
+            prepath = self.path[0:len(self.path)-1]
+            return self.method == other.method and other.path.startswith(prepath)
         return self.method == other.method and self.path == other.path
 
     def __repr__(self) -> str:


### PR DESCRIPTION
This change makes it possible to implement a RESTful API.

for example,
 `PUT /RGB/YELLOW`
 `PUT /RGB/GREEN`
 `PUT /RGB/<any_color>`

We can define these APIs in one handler.
`@server.route("/RGB/*", method=HTTPMethod.PUT)`

Thank you in advance for your consideration.