### PR TITLE
Feature: URL Parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,9 +26,10 @@ HTTP Server for CircuitPython.
 - Supports `socketpool` or `socket` as a source of sockets; can be used in CPython.
 - HTTP 1.1.
 - Serves files from a designated root.
-- Routing for serving computed responses from handler.
+- Routing for serving computed responses from handlers.
 - Gives access to request headers, query parameters, body and client's address, the one from which the request came.
 - Supports chunked transfer encoding.
+- Supports URL parameters and wildcard URLs.
 
 
 Dependencies

--- a/adafruit_httpserver/request.py
+++ b/adafruit_httpserver/request.py
@@ -133,7 +133,7 @@ class HTTPRequest:
             if "=" in query_param:
                 key, value = query_param.split("=", 1)
                 query_params[key] = value
-            else:
+            elif query_param:
                 query_params[query_param] = ""
 
         return method, path, query_params, http_version

--- a/adafruit_httpserver/response.py
+++ b/adafruit_httpserver/response.py
@@ -29,38 +29,38 @@ class HTTPResponse:
 
     Example::
 
-            # Response with 'Content-Length' header
-            @server.route(path, method)
-            def route_func(request):
+        # Response with 'Content-Length' header
+        @server.route(path, method)
+        def route_func(request):
 
-                response = HTTPResponse(request)
+            response = HTTPResponse(request)
+            response.send("Some content", content_type="text/plain")
+
+            # or
+
+            response = HTTPResponse(request)
+            with response:
+                response.send(body='Some content', content_type="text/plain")
+
+            # or
+
+            with HTTPResponse(request) as response:
                 response.send("Some content", content_type="text/plain")
 
-                # or
+        # Response with 'Transfer-Encoding: chunked' header
+        @server.route(path, method)
+        def route_func(request):
 
-                response = HTTPResponse(request)
-                with response:
-                    response.send(body='Some content', content_type="text/plain")
+            response = HTTPResponse(request, content_type="text/plain", chunked=True)
+            with response:
+                response.send_chunk("Some content")
+                response.send_chunk("Some more content")
 
-                # or
+            # or
 
-                with HTTPResponse(request) as response:
-                    response.send("Some content", content_type="text/plain")
-
-            # Response with 'Transfer-Encoding: chunked' header
-            @server.route(path, method)
-            def route_func(request):
-
-                response = HTTPResponse(request, content_type="text/plain", chunked=True)
-                with response:
-                    response.send_chunk("Some content")
-                    response.send_chunk("Some more content")
-
-                # or
-
-                with HTTPResponse(request, content_type="text/plain", chunked=True) as response:
-                    response.send_chunk("Some content")
-                    response.send_chunk("Some more content")
+            with HTTPResponse(request, content_type="text/plain", chunked=True) as response:
+                response.send_chunk("Some content")
+                response.send_chunk("Some more content")
     """
 
     request: HTTPRequest

--- a/adafruit_httpserver/route.py
+++ b/adafruit_httpserver/route.py
@@ -26,16 +26,17 @@ class _HTTPRoute:
 
         self.path = path if not contains_regex else re.sub(r"<\w*>", r"([^/]*)", path)
         self.method = method
-        self.regex = contains_regex
+        self._contains_regex = contains_regex
 
     def matches(self, other: "_HTTPRoute") -> bool:
         """
         Checks if the route matches the other route.
 
-        If the route contains parameters, it will check if the other route contains values for them.
+        If the route contains parameters, it will check if the ``other`` route contains values for
+        them.
         """
 
-        if self.regex or other.regex:
+        if self._contains_regex:
             return re.match(self.path, other.path) and self.method == other.method
 
         return self.method == other.method and self.path == other.path

--- a/adafruit_httpserver/route.py
+++ b/adafruit_httpserver/route.py
@@ -7,6 +7,13 @@
 * Author(s): Dan Halbert, Michał Pokusa
 """
 
+try:
+    from typing import Callable, List, Union
+except ImportError:
+    pass
+
+import re
+
 from .methods import HTTPMethod
 
 
@@ -15,14 +22,66 @@ class _HTTPRoute:
 
     def __init__(self, path: str = "", method: HTTPMethod = HTTPMethod.GET) -> None:
 
-        self.path = path
+        contains_regex = re.search(r"<\w*>", path)
+
+        self.path = path if not contains_regex else re.sub(r"<\w*>", r"([^/]*)", path)
         self.method = method
+        self.regex = contains_regex
 
-    def __hash__(self) -> int:
-        return hash(self.method) ^ hash(self.path)
+    def matches(self, other: "_HTTPRoute") -> bool:
+        """
+        Checks if the route matches the other route.
 
-    def __eq__(self, other: "_HTTPRoute") -> bool:
+        If the route contains parameters, it will check if the other route contains values for them.
+        """
+
+        if self.regex or other.regex:
+            return re.match(self.path, other.path) and self.method == other.method
+
         return self.method == other.method and self.path == other.path
 
     def __repr__(self) -> str:
         return f"HTTPRoute(path={repr(self.path)}, method={repr(self.method)})"
+
+
+class _HTTPRoutes:
+    """A collection of routes and their corresponding handlers."""
+
+    def __init__(self) -> None:
+        self._routes: List[_HTTPRoute] = []
+        self._handlers: List[Callable] = []
+
+    def add(self, route: _HTTPRoute, handler: Callable):
+        """Adds a route and its handler to the collection."""
+
+        self._routes.append(route)
+        self._handlers.append(handler)
+
+    def find_handler(self, route: _HTTPRoute) -> Union[Callable, None]:
+        """
+        Finds a handler for a given route.
+
+        If route used URL parameters, the handler will be wrapped to pass the parameters to the
+        handler.
+
+        Example::
+
+            @server.route("/example/<my_parameter>", HTTPMethod.GET)
+            def route_func(request, my_parameter):
+                ...
+                request.path == "/example/123" # True
+                my_parameter == "123" # True
+        """
+
+        try:
+            matched_route = next(filter(lambda r: r.matches(route), self._routes))
+        except StopIteration:
+            return None
+
+        handler = self._handlers[self._routes.index(matched_route)]
+        args = re.match(matched_route.path, route.path).groups()
+
+        def wrapper(request):
+            return handler(request, *args)
+
+        return wrapper

--- a/adafruit_httpserver/route.py
+++ b/adafruit_httpserver/route.py
@@ -59,7 +59,7 @@ class _HTTPRoute:
         return self._last_match_groups
 
     def __repr__(self) -> str:
-        return f"HTTPRoute(path={repr(self.path)}, method={repr(self.method)})"
+        return f"_HTTPRoute(path={repr(self.path)}, method={repr(self.method)})"
 
 
 class _HTTPRoutes:
@@ -103,3 +103,6 @@ class _HTTPRoutes:
             return handler(request, *args)
 
         return wrapper
+
+    def __repr__(self) -> str:
+        return f"_HTTPRoutes({repr(self._routes)})"

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -164,12 +164,7 @@ class HTTPServer:
 
                 # If a handler for route exists and is callable, call it.
                 if handler is not None and callable(handler):
-                    output = handler(request)
-                    # TODO: Remove this deprecation error in future
-                    if isinstance(output, HTTPResponse):
-                        raise RuntimeError(
-                            "Returning an HTTPResponse from a route handler is deprecated."
-                        )
+                    handler(request)
 
                 # If no handler exists and request method is GET, try to serve a file.
                 elif handler is None and request.method == HTTPMethod.GET:

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -43,13 +43,17 @@ class HTTPServer:
         """
         Decorator used to add a route.
 
-        :param str path: filename path
+        :param str path: URL path
         :param HTTPMethod method: HTTP method: HTTPMethod.GET, HTTPMethod.POST, etc.
 
         Example::
 
             @server.route("/example", HTTPMethod.GET)
             def route_func(request):
+                ...
+
+            @server.route("/example/<my_parameter>", HTTPMethod.GET)
+            def route_func(request, my_parameter):
                 ...
         """
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -36,7 +36,8 @@ Change NeoPixel color
 If you want your code to do more than just serve web pages,
 use the start/poll methods as shown in this example.
 
-For example by going to ``/change-neopixel-color?r=255&g=0&b=0`` you can change the color of the NeoPixel to red.
+For example by going to ``/change-neopixel-color?r=255&g=0&b=0`` or ``/change-neopixel-color/255/0/0``
+you can change the color of the NeoPixel to red.
 Tested on ESP32-S2 Feather.
 
 .. literalinclude:: ../examples/httpserver_neopixel.py
@@ -61,4 +62,29 @@ To use it, you need to set the ``chunked=True`` when creating a ``HTTPResponse``
 
 .. literalinclude:: ../examples/httpserver_chunked.py
     :caption: examples/httpserver_chunked.py
+    :linenos:
+
+URL parameters
+---------------------
+
+Alternatively to using query parameters, you can use URL parameters.
+
+In order to use URL parameters, you need to wrap them inside ``<>`` in ``HTTPServer.route``, e.g. ``<my_parameter>``.
+
+All URL parameters are passed as positional arguments to the handler function, in order they are specified.
+
+Notice how the handler function in example below accepts two additional arguments : ``device_id`` and ``action``.
+
+If you specify multiple routes for single handler function and they have different number of URL parameters,
+make sure to add default values for all the ones that might not be passed.
+In the example below the second route has only one URL parameter, so the ``action`` parameter has a default value of ``None``.
+
+Keep in mind that URL parameters are always passed as strings, so you need to convert them to the desired type.
+Also note that the names of the function parameters **do not have to match** with the ones used in route, but they **must** be in the same order.
+Look at the example below to see how the ``route_param_1`` and ``route_param_1`` are named differently in the handler function.
+
+Although it is possible, it makes more sens be consistent with the names of the parameters in the route and in the handler function.
+
+.. literalinclude:: ../examples/httpserver_url_parameters.py
+    :caption: examples/httpserver_url_parameters.py
     :linenos:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -71,19 +71,19 @@ Alternatively to using query parameters, you can use URL parameters.
 
 In order to use URL parameters, you need to wrap them inside ``<>`` in ``HTTPServer.route``, e.g. ``<my_parameter>``.
 
-All URL parameters are passed as positional arguments to the handler function, in order they are specified.
+All URL parameters are **passed as positional (not keyword) arguments** to the handler function, in order they are specified in ``HTTPServer.route``.
 
 Notice how the handler function in example below accepts two additional arguments : ``device_id`` and ``action``.
 
 If you specify multiple routes for single handler function and they have different number of URL parameters,
 make sure to add default values for all the ones that might not be passed.
-In the example below the second route has only one URL parameter, so the ``action`` parameter has a default value of ``None``.
+In the example below the second route has only one URL parameter, so the ``action`` parameter has a default value.
 
 Keep in mind that URL parameters are always passed as strings, so you need to convert them to the desired type.
 Also note that the names of the function parameters **do not have to match** with the ones used in route, but they **must** be in the same order.
 Look at the example below to see how the ``route_param_1`` and ``route_param_1`` are named differently in the handler function.
 
-Although it is possible, it makes more sens be consistent with the names of the parameters in the route and in the handler function.
+Although it is possible, it makes more sense be consistent with the names of the parameters in the route and in the handler function.
 
 .. literalinclude:: ../examples/httpserver_url_parameters.py
     :caption: examples/httpserver_url_parameters.py

--- a/examples/httpserver_neopixel.py
+++ b/examples/httpserver_neopixel.py
@@ -28,14 +28,27 @@ pixel = neopixel.NeoPixel(board.NEOPIXEL, 1)
 
 
 @server.route("/change-neopixel-color")
-def change_neopixel_color_handler(request: HTTPRequest):
+def change_neopixel_color_handler_query_params(request: HTTPRequest):
     """
-    Changes the color of the built-in NeoPixel.
+    Changes the color of the built-in NeoPixel using query/GET params.
     """
     r = request.query_params.get("r")
     g = request.query_params.get("g")
     b = request.query_params.get("b")
 
+    pixel.fill((int(r or 0), int(g or 0), int(b or 0)))
+
+    with HTTPResponse(request, content_type=MIMEType.TYPE_TXT) as response:
+        response.send(f"Changed NeoPixel to color ({r}, {g}, {b})")
+
+
+@server.route("/change-neopixel-color/<r>/<g>/<b>")
+def change_neopixel_color_handler_url_params(
+    request: HTTPRequest, r: str, g: str, b: str
+):
+    """
+    Changes the color of the built-in NeoPixel using URL params.
+    """
     pixel.fill((int(r or 0), int(g or 0), int(b or 0)))
 
     with HTTPResponse(request, content_type=MIMEType.TYPE_TXT) as response:

--- a/examples/httpserver_url_parameters.py
+++ b/examples/httpserver_url_parameters.py
@@ -25,10 +25,10 @@ server = HTTPServer(pool)
 
 class Device:
     def turn_on(self):
-        raise NotImplementedError
+        print("Turning on device.")
 
     def turn_off(self):
-        raise NotImplementedError
+        print("Turning off device.")
 
 
 def get_device(device_id: str) -> Device:  # pylint: disable=unused-argument
@@ -40,17 +40,21 @@ def get_device(device_id: str) -> Device:  # pylint: disable=unused-argument
 
 @server.route("/device/<device_id>/action/<action>")
 @server.route("/device/emergency-power-off/<device_id>")
-def perform_action(request: HTTPRequest, device_id: str, action: str = None):
+def perform_action(request: HTTPRequest, device_id: str, action: str = "emergency_power_off"):
     """
     Performs an "action" on a specified device.
     """
 
     device = get_device(device_id)
 
-    if action == "turn_on":
+    if action in ["turn_on",]:
         device.turn_on()
-    elif action == "turn_off" or action is None:
+    elif action in ["turn_off", "emergency_power_off"]:
         device.turn_off()
+    else:
+        with HTTPResponse(request, content_type=MIMEType.TYPE_TXT) as response:
+            response.send(f"Unknown action ({action})")
+        return
 
     with HTTPResponse(request, content_type=MIMEType.TYPE_TXT) as response:
         response.send(f"Action ({action}) performed on device with ID: {device_id}")

--- a/examples/httpserver_url_parameters.py
+++ b/examples/httpserver_url_parameters.py
@@ -24,10 +24,10 @@ server = HTTPServer(pool)
 
 
 class Device:
-    def turn_on(self):
+    def turn_on(self):  # pylint: disable=no-self-use
         print("Turning on device.")
 
-    def turn_off(self):
+    def turn_off(self):  # pylint: disable=no-self-use
         print("Turning off device.")
 
 
@@ -40,14 +40,16 @@ def get_device(device_id: str) -> Device:  # pylint: disable=unused-argument
 
 @server.route("/device/<device_id>/action/<action>")
 @server.route("/device/emergency-power-off/<device_id>")
-def perform_action(request: HTTPRequest, device_id: str, action: str = "emergency_power_off"):
+def perform_action(
+    request: HTTPRequest, device_id: str, action: str = "emergency_power_off"
+):
     """
     Performs an "action" on a specified device.
     """
 
     device = get_device(device_id)
 
-    if action in ["turn_on",]:
+    if action in ["turn_on"]:
         device.turn_on()
     elif action in ["turn_off", "emergency_power_off"]:
         device.turn_off()

--- a/examples/httpserver_url_parameters.py
+++ b/examples/httpserver_url_parameters.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+import secrets  # pylint: disable=no-name-in-module
+
+import socketpool
+import wifi
+
+from adafruit_httpserver.mime_type import MIMEType
+from adafruit_httpserver.request import HTTPRequest
+from adafruit_httpserver.response import HTTPResponse
+from adafruit_httpserver.server import HTTPServer
+
+
+ssid, password = secrets.WIFI_SSID, secrets.WIFI_PASSWORD  # pylint: disable=no-member
+
+print("Connecting to", ssid)
+wifi.radio.connect(ssid, password)
+print("Connected to", ssid)
+
+pool = socketpool.SocketPool(wifi.radio)
+server = HTTPServer(pool)
+
+
+class Device:
+    def turn_on(self):
+        raise NotImplementedError
+
+    def turn_off(self):
+        raise NotImplementedError
+
+
+def get_device(device_id: str) -> Device:  # pylint: disable=unused-argument
+    """
+    This is a **made up** function that returns a `Device` object.
+    """
+    return Device()
+
+
+@server.route("/device/<device_id>/action/<action>")
+@server.route("/device/emergency-power-off/<device_id>")
+def perform_action(request: HTTPRequest, device_id: str, action: str = None):
+    """
+    Performs an "action" on a specified device.
+    """
+
+    device = get_device(device_id)
+
+    if action == "turn_on":
+        device.turn_on()
+    elif action == "turn_off" or action is None:
+        device.turn_off()
+
+    with HTTPResponse(request, content_type=MIMEType.TYPE_TXT) as response:
+        response.send(f"Action ({action}) performed on device with ID: {device_id}")
+
+
+@server.route("/something/<route_param_1>/<route_param_2>")
+def different_name_parameters(
+    request: HTTPRequest,
+    handler_param_1: str,  #  pylint: disable=unused-argument
+    handler_param_2: str = None,  #  pylint: disable=unused-argument
+):
+    """
+    Presents that the parameters can be named anything.
+
+    ``route_param_1`` -> ``handler_param_1``
+    ``route_param_2`` -> ``handler_param_2``
+    """
+
+    with HTTPResponse(request, content_type=MIMEType.TYPE_TXT) as response:
+        response.send("200 OK")
+
+
+print(f"Listening on http://{wifi.radio.ipv4_address}:80")
+server.serve_forever(str(wifi.radio.ipv4_address))


### PR DESCRIPTION
Added option for wildcard-like URLs in `HTTPServer.route`.

It is now possible to do something like this:

```python
@server.route("/something/<param_1>/<param_2>")
def name_parameters(request: HTTPRequest, param_1: str,  param_2: str = None):
    ...
```

and access parameters inside handler function, similarly to Django and I belive Flask.

Also updated examples to show new functionality.

There is literally no change to the API so this is 100% backwards compatible, if one does not use `<>` in route call, nothing changes for them.

Additionally:
- Fixed one small issue where an empty query params was created

These changes should fulfill #42.