### PR TITLE
Fix infinite loop when requesting too quickly

### DIFF
--- a/adafruit_httpserver/response.py
+++ b/adafruit_httpserver/response.py
@@ -245,5 +245,7 @@ class HTTPResponse:
             except OSError as exc:
                 if exc.errno == EAGAIN:
                     continue
-                if exc.errno == ECONNRESET:
+                elif exc.errno == ECONNRESET:
                     return
+                else:
+                    raise exc

--- a/adafruit_httpserver/response.py
+++ b/adafruit_httpserver/response.py
@@ -245,7 +245,6 @@ class HTTPResponse:
             except OSError as exc:
                 if exc.errno == EAGAIN:
                     continue
-                elif exc.errno == ECONNRESET:
+                if exc.errno == ECONNRESET:
                     return
-                else:
-                    raise exc
+                raise

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -104,6 +104,7 @@ class HTTPServer:
             except OSError as ex:
                 if ex.errno == ETIMEDOUT:
                     break
+                raise
             except Exception as ex:
                 raise ex
         return received_bytes
@@ -122,6 +123,7 @@ class HTTPServer:
             except OSError as ex:
                 if ex.errno == ETIMEDOUT:
                     break
+                raise
             except Exception as ex:
                 raise ex
         return received_body_bytes[:content_length]


### PR DESCRIPTION
On the Pico W we can get in an infinite loop if we request pages too quickly. This is because we get an OSError 32 Broken Pipe back from which we can't recover. I've made it so any of the unexpected errors will be re-raised.

Fixes this issue:
https://github.com/adafruit/Adafruit_CircuitPython_HTTPServer/issues/44

I also wonder if the same issue can happen in  `server._receive_header_bytes` / `server._receive_body_bytes`  which has very similar code that catches and swallows OSError unless it is ETIMEDOUT ?
