### PR TITLE
Allow no route to be defined for only serving static files

### DIFF
--- a/adafruit_httpserver/route.py
+++ b/adafruit_httpserver/route.py
@@ -106,7 +106,7 @@ class _HTTPRoutes:
                 my_parameter == "123" # True
         """
         if not self._routes:
-            raise ValueError("No routes added")
+            return None
 
         found_route, _route = False, None
 


### PR DESCRIPTION
Just removed the exception when no route has been setup.
Makes something like that work to serve a static website.
```py
import os
import socketpool
import wifi
from adafruit_httpserver.server import HTTPServer

PORT = 80
ROOT = "/www"

wifi.radio.connect(os.getenv("WIFI_SSID"), os.getenv("WIFI_PASSWORD"))
pool = socketpool.SocketPool(wifi.radio)
server = HTTPServer(pool)

print(f"Listening on http://{wifi.radio.ipv4_address}:{PORT}")
server.serve_forever(str(wifi.radio.ipv4_address), port=PORT, root_path=ROOT)
```