### PR TITLE
Allow HEAD requests to files paths

### DIFF
--- a/adafruit_httpserver/response.py
+++ b/adafruit_httpserver/response.py
@@ -172,6 +172,7 @@ class HTTPResponse:
         filename: str = "index.html",
         root_path: str = "./",
         buffer_size: int = 1024,
+        head_only: bool = False,
     ) -> None:
         """
         Send response with content of ``filename`` located in ``root_path``.
@@ -197,9 +198,10 @@ class HTTPResponse:
             content_length=file_length,
         )
 
-        with open(root_path + filename, "rb") as file:
-            while bytes_read := file.read(buffer_size):
-                self._send_bytes(self.request.connection, bytes_read)
+        if not head_only:
+            with open(root_path + filename, "rb") as file:
+                while bytes_read := file.read(buffer_size):
+                    self._send_bytes(self.request.connection, bytes_read)
         self._response_already_sent = True
 
     def send_chunk(self, chunk: str = "") -> None:

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -167,12 +167,16 @@ class HTTPServer:
                     handler(request)
 
                 # If no handler exists and request method is GET, try to serve a file.
-                elif handler is None and request.method == HTTPMethod.GET:
+                elif handler is None and request.method in (
+                    HTTPMethod.GET,
+                    HTTPMethod.HEAD,
+                ):
                     filename = "index.html" if request.path == "/" else request.path
                     HTTPResponse(request).send_file(
                         filename=filename,
                         root_path=self.root_path,
                         buffer_size=self.request_buffer_size,
+                        head_only=(request.method == HTTPMethod.HEAD),
                     )
                 else:
                     HTTPResponse(


### PR DESCRIPTION
Allows these instead of a 400 status for static files.
Leaves user-created routes to handle this on their own.
```
❯ curl -I http://192.168.1.28/index.html
HTTP/1.1 200 OK
Content-Length: 644
Content-Type: text/html
Connection: close
```
```
❯ curl -I http://192.168.1.28/NOFILE
HTTP/1.1 404 Not Found
Content-Length: 0
Content-Type: text/plain
Connection: close
```