### PR TITLE
Prevent parent directory access, custom Errors

### DIFF
--- a/adafruit_httpserver/exceptions.py
+++ b/adafruit_httpserver/exceptions.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`adafruit_httpserver.exceptions`
+====================================================
+* Author(s): Michał Pokusa
+"""
+
+
+class InvalidPathError(Exception):
+    """
+    Parent class for all path related errors.
+    """
+
+
+class ParentDirectoryReferenceError(InvalidPathError):
+    """
+    Path contains ``..``, a reference to the parent directory.
+    """
+
+    def __init__(self, path: str) -> None:
+        """Creates a new ``ParentDirectoryReferenceError`` for the ``path``."""
+        super().__init__(f"Parent directory reference in path: {path}")
+
+
+class BackslashInPathError(InvalidPathError):
+    """
+    Backslash ``\\`` in path.
+    """
+
+    def __init__(self, path: str) -> None:
+        """Creates a new ``BackslashInPathError`` for the ``path``."""
+        super().__init__(f"Backslash in path: {path}")
+
+
+class ResponseAlreadySentException(Exception):
+    """
+    Another ``HTTPResponse`` has already been sent. There can only be one per ``HTTPRequest``.
+    """
+
+
+class FileNotExistsError(Exception):
+    """
+    Raised when a file does not exist.
+    """
+
+    def __init__(self, path: str) -> None:
+        """
+        Creates a new ``FileNotExistsError`` for the file at ``path``.
+        """
+        super().__init__(f"File does not exist: {path}")

--- a/adafruit_httpserver/exceptions.py
+++ b/adafruit_httpserver/exceptions.py
@@ -34,7 +34,7 @@ class BackslashInPathError(InvalidPathError):
         super().__init__(f"Backslash in path: {path}")
 
 
-class ResponseAlreadySentException(Exception):
+class ResponseAlreadySentError(Exception):
     """
     Another ``HTTPResponse`` has already been sent. There can only be one per ``HTTPRequest``.
     """

--- a/adafruit_httpserver/response.py
+++ b/adafruit_httpserver/response.py
@@ -235,6 +235,8 @@ class HTTPResponse:
 
         if not root_path.endswith("/"):
             root_path += "/"
+        if filename.startswith("/"):
+            filename = filename[1:]
 
         full_file_path = root_path + filename
 

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -155,6 +155,7 @@ class HTTPServer:
                     conn, received_body_bytes, content_length
                 )
 
+                # Find a handler for the route
                 handler = self.routes.find_handler(
                     _HTTPRoute(request.path, request.method)
                 )
@@ -176,13 +177,13 @@ class HTTPServer:
                         request, status=CommonHTTPStatus.BAD_REQUEST_400
                     ).send()
 
-        except OSError as ex:
-            # handle EAGAIN and ECONNRESET
-            if ex.errno == EAGAIN:
-                # there is no data available right now, try again later.
+        except OSError as error:
+            # Handle EAGAIN and ECONNRESET
+            if error.errno == EAGAIN:
+                # There is no data available right now, try again later.
                 return
-            if ex.errno == ECONNRESET:
-                # connection reset by peer, try again later.
+            if error.errno == ECONNRESET:
+                # Connection reset by peer, try again later.
                 return
             raise
 

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -26,18 +26,19 @@ from .status import CommonHTTPStatus
 class HTTPServer:
     """A basic socket-based HTTP server."""
 
-    def __init__(self, socket_source: Protocol) -> None:
+    def __init__(self, socket_source: Protocol, root_path: str) -> None:
         """Create a server, and get it ready to run.
 
         :param socket: An object that is a source of sockets. This could be a `socketpool`
           in CircuitPython or the `socket` module in CPython.
+        :param str root_path: Root directory to serve files from
         """
         self._buffer = bytearray(1024)
         self._timeout = 1
         self.routes = _HTTPRoutes()
         self._socket_source = socket_source
         self._sock = None
-        self.root_path = "/"
+        self.root_path = root_path
 
     def route(self, path: str, method: HTTPMethod = HTTPMethod.GET) -> Callable:
         """
@@ -63,14 +64,13 @@ class HTTPServer:
 
         return route_decorator
 
-    def serve_forever(self, host: str, port: int = 80, root_path: str = "") -> None:
+    def serve_forever(self, host: str, port: int = 80) -> None:
         """Wait for HTTP requests at the given host and port. Does not return.
 
         :param str host: host name or IP address
         :param int port: port
-        :param str root_path: root directory to serve files from
         """
-        self.start(host, port, root_path)
+        self.start(host, port)
 
         while True:
             try:
@@ -78,17 +78,14 @@ class HTTPServer:
             except OSError:
                 continue
 
-    def start(self, host: str, port: int = 80, root_path: str = "") -> None:
+    def start(self, host: str, port: int = 80) -> None:
         """
         Start the HTTP server at the given host and port. Requires calling
         poll() in a while loop to handle incoming requests.
 
         :param str host: host name or IP address
         :param int port: port
-        :param str root_path: root directory to serve files from
         """
-        self.root_path = root_path
-
         self._sock = self._socket_source.socket(
             self._socket_source.AF_INET, self._socket_source.SOCK_STREAM
         )

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -210,7 +210,7 @@ class HTTPServer:
 
         Example::
 
-            server = HTTPServer(pool)
+            server = HTTPServer(pool, "/static")
             server.request_buffer_size = 2048
 
             server.serve_forever(str(wifi.radio.ipv4_address))
@@ -232,7 +232,7 @@ class HTTPServer:
 
         Example::
 
-            server = HTTPServer(pool)
+            server = HTTPServer(pool, "/static")
             server.socket_timeout = 3
 
             server.serve_forever(str(wifi.radio.ipv4_address))

--- a/adafruit_httpserver/status.py
+++ b/adafruit_httpserver/status.py
@@ -39,6 +39,9 @@ class CommonHTTPStatus(HTTPStatus):  # pylint: disable=too-few-public-methods
     BAD_REQUEST_400 = HTTPStatus(400, "Bad Request")
     """400 Bad Request"""
 
+    FORBIDDEN_403 = HTTPStatus(403, "Forbidden")
+    """403 Forbidden"""
+
     NOT_FOUND_404 = HTTPStatus(404, "Not Found")
     """404 Not Found"""
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,3 +27,6 @@
 
 .. automodule:: adafruit_httpserver.mime_type
     :members:
+
+.. automodule:: adafruit_httpserver.exceptions
+    :members:

--- a/examples/httpserver_chunked.py
+++ b/examples/httpserver_chunked.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-import secrets  # pylint: disable=no-name-in-module
+import os
 
 import socketpool
 import wifi
@@ -12,7 +12,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid, password = secrets.WIFI_SSID, secrets.WIFI_PASSWORD  # pylint: disable=no-member
+ssid = os.environ.get("WIFI_SSID")
+password = os.environ.get("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_chunked.py
+++ b/examples/httpserver_chunked.py
@@ -19,7 +19,7 @@ wifi.radio.connect(ssid, password)
 print("Connected to", ssid)
 
 pool = socketpool.SocketPool(wifi.radio)
-server = HTTPServer(pool)
+server = HTTPServer(pool, "/static")
 
 
 @server.route("/chunked")

--- a/examples/httpserver_chunked.py
+++ b/examples/httpserver_chunked.py
@@ -12,8 +12,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid = os.environ.get("WIFI_SSID")
-password = os.environ.get("WIFI_PASSWORD")
+ssid = os.getenv("WIFI_SSID")
+password = os.getenv("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_cpu_information.py
+++ b/examples/httpserver_cpu_information.py
@@ -15,8 +15,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid = os.environ.get("WIFI_SSID")
-password = os.environ.get("WIFI_PASSWORD")
+ssid = os.getenv("WIFI_SSID")
+password = os.getenv("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_cpu_information.py
+++ b/examples/httpserver_cpu_information.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-import secrets  # pylint: disable=no-name-in-module
+import os
 
 import json
 import microcontroller
@@ -15,7 +15,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid, password = secrets.WIFI_SSID, secrets.WIFI_PASSWORD  # pylint: disable=no-member
+ssid = os.environ.get("WIFI_SSID")
+password = os.environ.get("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_cpu_information.py
+++ b/examples/httpserver_cpu_information.py
@@ -22,7 +22,7 @@ wifi.radio.connect(ssid, password)
 print("Connected to", ssid)
 
 pool = socketpool.SocketPool(wifi.radio)
-server = HTTPServer(pool)
+server = HTTPServer(pool, "/static")
 
 
 @server.route("/cpu-information")

--- a/examples/httpserver_mdns.py
+++ b/examples/httpserver_mdns.py
@@ -14,8 +14,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid = os.environ.get("WIFI_SSID")
-password = os.environ.get("WIFI_PASSWORD")
+ssid = os.getenv("WIFI_SSID")
+password = os.getenv("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_mdns.py
+++ b/examples/httpserver_mdns.py
@@ -25,7 +25,7 @@ mdns_server.hostname = "custom-mdns-hostname"
 mdns_server.advertise_service(service_type="_http", protocol="_tcp", port=80)
 
 pool = socketpool.SocketPool(wifi.radio)
-server = HTTPServer(pool)
+server = HTTPServer(pool, "/static")
 
 
 @server.route("/")

--- a/examples/httpserver_mdns.py
+++ b/examples/httpserver_mdns.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-import secrets  # pylint: disable=no-name-in-module
+import os
 
 import mdns
 import socketpool
@@ -14,7 +14,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid, password = secrets.WIFI_SSID, secrets.WIFI_PASSWORD  # pylint: disable=no-member
+ssid = os.environ.get("WIFI_SSID")
+password = os.environ.get("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_neopixel.py
+++ b/examples/httpserver_neopixel.py
@@ -22,7 +22,7 @@ wifi.radio.connect(ssid, password)
 print("Connected to", ssid)
 
 pool = socketpool.SocketPool(wifi.radio)
-server = HTTPServer(pool)
+server = HTTPServer(pool, "/static")
 
 pixel = neopixel.NeoPixel(board.NEOPIXEL, 1)
 

--- a/examples/httpserver_neopixel.py
+++ b/examples/httpserver_neopixel.py
@@ -15,8 +15,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid = os.environ.get("WIFI_SSID")
-password = os.environ.get("WIFI_PASSWORD")
+ssid = os.getenv("WIFI_SSID")
+password = os.getenv("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_neopixel.py
+++ b/examples/httpserver_neopixel.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-import secrets  # pylint: disable=no-name-in-module
+import os
 
 import board
 import neopixel
@@ -15,7 +15,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid, password = secrets.WIFI_SSID, secrets.WIFI_PASSWORD  # pylint: disable=no-member
+ssid = os.environ.get("WIFI_SSID")
+password = os.environ.get("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_simple_poll.py
+++ b/examples/httpserver_simple_poll.py
@@ -20,7 +20,7 @@ wifi.radio.connect(ssid, password)
 print("Connected to", ssid)
 
 pool = socketpool.SocketPool(wifi.radio)
-server = HTTPServer(pool)
+server = HTTPServer(pool, "/static")
 
 
 @server.route("/")

--- a/examples/httpserver_simple_poll.py
+++ b/examples/httpserver_simple_poll.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-import secrets  # pylint: disable=no-name-in-module
+import os
 
 import socketpool
 import wifi
@@ -13,7 +13,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid, password = secrets.WIFI_SSID, secrets.WIFI_PASSWORD  # pylint: disable=no-member
+ssid = os.environ.get("WIFI_SSID")
+password = os.environ.get("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_simple_poll.py
+++ b/examples/httpserver_simple_poll.py
@@ -13,8 +13,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid = os.environ.get("WIFI_SSID")
-password = os.environ.get("WIFI_PASSWORD")
+ssid = os.getenv("WIFI_SSID")
+password = os.getenv("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_simple_serve.py
+++ b/examples/httpserver_simple_serve.py
@@ -20,7 +20,7 @@ wifi.radio.connect(ssid, password)
 print("Connected to", ssid)
 
 pool = socketpool.SocketPool(wifi.radio)
-server = HTTPServer(pool)
+server = HTTPServer(pool, "/static")
 
 
 @server.route("/")

--- a/examples/httpserver_simple_serve.py
+++ b/examples/httpserver_simple_serve.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-import secrets  # pylint: disable=no-name-in-module
+import os
 
 import socketpool
 import wifi
@@ -13,7 +13,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid, password = secrets.WIFI_SSID, secrets.WIFI_PASSWORD  # pylint: disable=no-member
+ssid = os.environ.get("WIFI_SSID")
+password = os.environ.get("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_simple_serve.py
+++ b/examples/httpserver_simple_serve.py
@@ -13,8 +13,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid = os.environ.get("WIFI_SSID")
-password = os.environ.get("WIFI_PASSWORD")
+ssid = os.getenv("WIFI_SSID")
+password = os.getenv("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_url_parameters.py
+++ b/examples/httpserver_url_parameters.py
@@ -20,7 +20,7 @@ wifi.radio.connect(ssid, password)
 print("Connected to", ssid)
 
 pool = socketpool.SocketPool(wifi.radio)
-server = HTTPServer(pool)
+server = HTTPServer(pool, "/static")
 
 
 class Device:

--- a/examples/httpserver_url_parameters.py
+++ b/examples/httpserver_url_parameters.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-import secrets  # pylint: disable=no-name-in-module
+import os
 
 import socketpool
 import wifi
@@ -13,7 +13,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid, password = secrets.WIFI_SSID, secrets.WIFI_PASSWORD  # pylint: disable=no-member
+ssid = os.environ.get("WIFI_SSID")
+password = os.environ.get("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)

--- a/examples/httpserver_url_parameters.py
+++ b/examples/httpserver_url_parameters.py
@@ -13,8 +13,8 @@ from adafruit_httpserver.response import HTTPResponse
 from adafruit_httpserver.server import HTTPServer
 
 
-ssid = os.environ.get("WIFI_SSID")
-password = os.environ.get("WIFI_PASSWORD")
+ssid = os.getenv("WIFI_SSID")
+password = os.getenv("WIFI_PASSWORD")
 
 print("Connecting to", ssid)
 wifi.radio.connect(ssid, password)


### PR DESCRIPTION
**Part of v3 Milestone, contains some minor breaking changes**
_If possible, please do not make it a separate "Release"_

This PR prevents accessing files outside root server directory, Previously, when there was a ".." in path it was possible to do that, which was unsecure as users could access files with configuration or secrets, or any other file.

All paths are now checked by default, whether they contain `".."` or `"\"` (backslash) inside. if that is teh sace a `403 Forbidden` is returned.

In order to keep everything readable in clean, I intruduced custom exceptions, instead of raising e.g. `RunTimeError` or `ValueError` with a comment, now `InvalidPathError` or `ResponseAlreadySentError`.

Server's `root_path` is now specified in constructor, not in `server_forever` or `pool` methods.

Some minor refactor to separate logic for diffrent smaller tasks inside `HTTPResponse`.

Updated examples to use new constructor and to use `settings.toml` instead of `secrets.py`.