### PR TITLE
changes for package instead of module

### DIFF
--- a/.github/workflows/release_gh.yml
+++ b/.github/workflows/release_gh.yml
@@ -17,3 +17,4 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         upload-url: ${{ github.event.release.upload_url }}
+        package-prefix: adafruit_httpserver

--- a/.github/workflows/release_gh.yml
+++ b/.github/workflows/release_gh.yml
@@ -17,4 +17,3 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         upload-url: ${{ github.event.release.upload_url }}
-        package-prefix: adafruit_httpserver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools]
-py-modules = ["adafruit_httpserver"]
+packages = ["adafruit_httpserver"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
I think this should resolve: #56 

I found these places to change by looking at the TODOs in a fresh cookie cutter library. 

The release_gh.yml one I am less sure about. There was a TODO for it in the new template, but the released mpy files in this repo seem to have been generated correctly even without this change so I'm not sure whether it's actually needed here or not.