### PR TITLE
XSS hardening

### DIFF
--- a/adafruit_httpserver/request.py
+++ b/adafruit_httpserver/request.py
@@ -35,6 +35,7 @@ class _IFieldStorage:
 
     @staticmethod
     def _html_output_encode(value):
+        """Encodes unsafe HTML characters."""
         return (
             str(value)
             .replace("&", "&amp;")
@@ -46,7 +47,7 @@ class _IFieldStorage:
 
     @staticmethod
     def _debug_warning_nonencoded_output():
-        """Warns about exposing all files on the device."""
+        """Warns about XSS risks."""
         print(
             "WARNING: Setting html_output_encode to False makes XSS vulnerabilities possible by "
             "allowing access to raw untrusted values submitted by users. If this data is reflected "

--- a/adafruit_httpserver/request.py
+++ b/adafruit_httpserver/request.py
@@ -33,7 +33,8 @@ class _IFieldStorage:
         else:
             self._storage[field_name].append(value)
 
-    def _html_output_encode(self, value):
+    @staticmethod
+    def _html_output_encode(value):
         return (
             str(value)
             .replace("&", "&amp;")
@@ -43,12 +44,13 @@ class _IFieldStorage:
             .replace("'", "&#x27;")
         )
 
-    def _debug_warning_nonencoded_output(self):
+    @staticmethod
+    def _debug_warning_nonencoded_output():
         """Warns about exposing all files on the device."""
         print(
-            f"WARNING: Setting html_output_encode to False will make XSS vulnerabilities possible by "
+            "WARNING: Setting html_output_encode to False makes XSS vulnerabilities possible by "
             "allowing access to raw untrusted values submitted by users. If this data is reflected "
-            "or shown within HTML without proper encoding it could enable Cross-Site Scripting attacks."
+            "or shown within HTML without proper encoding it could enable Cross-Site Scripting."
         )
 
     def get(
@@ -57,9 +59,9 @@ class _IFieldStorage:
         """Get the value of a field."""
         if html_output_encode:
             return self._html_output_encode(self._storage.get(field_name, [default])[0])
-        else:
-            self._debug_warning_nonencoded_output()
-            return self._storage.get(field_name, [default])[0]
+
+        self._debug_warning_nonencoded_output()
+        return self._storage.get(field_name, [default])[0]
 
     def get_list(self, field_name: str) -> List[Union[str, bytes]]:
         """Get the list of values of a field."""

--- a/adafruit_httpserver/request.py
+++ b/adafruit_httpserver/request.py
@@ -50,7 +50,9 @@ class _IFieldStorage:
     ) -> Union[str, bytes, None]:
         """Get the value of a field."""
         if safe:
-            return self._encode_html_entities(self._storage.get(field_name, [default])[0])
+            return self._encode_html_entities(
+                self._storage.get(field_name, [default])[0]
+            )
 
         _debug_warning_nonencoded_output()
         return self._storage.get(field_name, [default])[0]

--- a/adafruit_httpserver/request.py
+++ b/adafruit_httpserver/request.py
@@ -33,9 +33,33 @@ class _IFieldStorage:
         else:
             self._storage[field_name].append(value)
 
-    def get(self, field_name: str, default: Any = None) -> Union[str, bytes, None]:
+    def _html_output_encode(self, value):
+        return (
+            str(value)
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+            .replace("'", "&#x27;")
+        )
+
+    def _debug_warning_nonencoded_output(self):
+        """Warns about exposing all files on the device."""
+        print(
+            f"WARNING: Setting html_output_encode to False will make XSS vulnerabilities possible by "
+            "allowing access to raw untrusted values submitted by users. If this data is reflected "
+            "or shown within HTML without proper encoding it could enable Cross-Site Scripting attacks."
+        )
+
+    def get(
+        self, field_name: str, default: Any = None, html_output_encode=True
+    ) -> Union[str, bytes, None]:
         """Get the value of a field."""
-        return self._storage.get(field_name, [default])[0]
+        if html_output_encode:
+            return self._html_output_encode(self._storage.get(field_name, [default])[0])
+        else:
+            self._debug_warning_nonencoded_output()
+            return self._storage.get(field_name, [default])[0]
 
     def get_list(self, field_name: str) -> List[Union[str, bytes]]:
         """Get the list of values of a field."""


### PR DESCRIPTION
The current server implementation and basic form_data example here: https://github.com/adafruit/Adafruit_CircuitPython_HTTPServer/blob/main/examples/httpserver_form_data.py are susceptible to XSS by submitting things like `<script>alert('xss');</script>` to the input box which then gets reflected back onto the page returned in the response and executed by the client browser.

By implementing this inside of FormData (super class) it means that by default user code will only have access to encoded values from the user rather than the actual raw values submitted. In some cases that might be problematic, for instance if the values aren't meant to be output within HTML, or if the intention is to allow the user to submit HTML content. In such cases the user could pass `False` to disable the encoding and implement their own prevention measures.

This PR does mitigate the risk with the provided example, however it is not all encompassing. There are still ways to write handlers and webpages that are vulnerable to other types of XSS like payloads injected into JS or CSS code instead of HTML. It might be good to ultimately add similar default prevention measures for JS and CSS contexts. 

Another potential idea is to eventually add a section within the examples with clearly labeled and documented "Examples of what NOT to do" that illustrate the insecurely implemented handlers and explain what risks they pose.


@michalpokusa I'm curious if you have any thoughts or ideas around this or any other potential "guardrails" against XSS within the server.
