### PR TITLE
Alternative import to `hashlib` and warning message about Websocket support

### DIFF
--- a/adafruit_httpserver/response.py
+++ b/adafruit_httpserver/response.py
@@ -17,8 +17,18 @@ except ImportError:
 import os
 import json
 from binascii import b2a_base64
-import hashlib
 from errno import EAGAIN, ECONNRESET, ETIMEDOUT, ENOTCONN
+
+try:
+    try:
+        import hashlib
+    except ImportError:
+        import adafruit_hashlib as hashlib
+except ImportError:
+    print(
+        "WARNING: hashlib module not available and adafruit_hashlib not installed.",
+        "Websocket support will not work.",
+    )
 
 from .exceptions import (
     BackslashInPathError,


### PR DESCRIPTION
🛠️ Updated/Changed:

- `hashlib` in `response.py` now has an alternative import - `adafruit_hashlib`. Fixes #73 
- If neither `hashlib` or `adafruit_hashlib` are available, the library will **not** raise an error and print a warning that Websocket support is not available. 

![image](https://github.com/adafruit/Adafruit_CircuitPython_HTTPServer/assets/72110769/d4a0f895-4c6e-434f-9844-8d87b158a9db)
