### PR TITLE
`Route` refactor and fixes, CPython example

### DIFF
--- a/adafruit_httpserver/route.py
+++ b/adafruit_httpserver/route.py
@@ -8,7 +8,7 @@
 """
 
 try:
-    from typing import Callable, List, Iterable, Union, Tuple, Dict, TYPE_CHECKING
+    from typing import Callable, Iterable, Union, Tuple, Literal, Dict, TYPE_CHECKING
 
     if TYPE_CHECKING:
         from .response import Response
@@ -36,13 +36,18 @@ class Route:
         self.parameters_names = [
             name[1:-1] for name in re.compile(r"/[^<>]*/?").split(path) if name != ""
         ]
-        self.path = re.sub(r"<\w+>", r"([^/]+)", path).replace("....", r".+").replace(
-            "...", r"[^/]+"
-        ) + ("/?" if append_slash else "")
+        self.path_pattern = re.compile(
+            r"^"
+            + re.sub(r"<\w+>", r"([^/]+)", path)
+            .replace(r"....", r".+")
+            .replace(r"...", r"[^/]+")
+            + (r"/?" if append_slash else r"")
+            + r"$"
+        )
+        self.path = path
         self.methods = (
             set(methods) if isinstance(methods, (set, list, tuple)) else set([methods])
         )
-
         self.handler = handler
 
     @staticmethod
@@ -56,7 +61,9 @@ class Route:
         if path.endswith("/") and append_slash:
             raise ValueError("Cannot use append_slash=True when path ends with /")
 
-    def match(self, other: "Route") -> Tuple[bool, Dict[str, str]]:
+    def matches(
+        self, method: str, path: str
+    ) -> Union[Tuple[Literal[False], None], Tuple[Literal[True], Dict[str, str]]]:
         """
         Checks if the route matches the other route.
 
@@ -68,45 +75,41 @@ class Route:
 
         Examples::
 
-            route = Route("/example", GET, True)
+            route = Route("/example", GET, append_slash=True)
 
-            other1a = Route("/example", GET)
-            other1b = Route("/example/", GET)
-            route.matches(other1a) # True, {}
-            route.matches(other1b) # True, {}
+            route.matches(GET, "/example") # True, {}
+            route.matches(GET, "/example/") # True, {}
 
-            other2 = Route("/other-example", GET)
-            route.matches(other2) # False, {}
+            route.matches(GET, "/other-example") # False, None
+            route.matches(POST, "/example/") # False, None
 
             ...
 
             route = Route("/example/<parameter>", GET)
 
-            other1 = Route("/example/123", GET)
-            route.matches(other1) # True, {"parameter": "123"}
+            route.matches(GET, "/example/123") # True, {"parameter": "123"}
 
-            other2 = Route("/other-example", GET)
-            route.matches(other2) # False, {}
+            route.matches(GET, "/other-example") # False, None
 
             ...
 
-            route1 = Route("/example/.../something", GET)
-            other1 = Route("/example/123/something", GET)
-            route1.matches(other1) # True, {}
+            route = Route("/example/.../something", GET)
+            route.matches(GET, "/example/123/something") # True, {}
 
-            route2 = Route("/example/..../something", GET)
-            other2 = Route("/example/123/456/something", GET)
-            route2.matches(other2) # True, {}
+            route = Route("/example/..../something", GET)
+            route.matches(GET, "/example/123/456/something") # True, {}
         """
 
-        if not other.methods.issubset(self.methods):
-            return False, {}
+        if method not in self.methods:
+            return False, None
 
-        regex_match = re.match(f"^{self.path}$", other.path)
-        if regex_match is None:
-            return False, {}
+        path_match = self.path_pattern.match(path)
+        if path_match is None:
+            return False, None
 
-        return True, dict(zip(self.parameters_names, regex_match.groups()))
+        url_parameters_values = path_match.groups()
+
+        return True, dict(zip(self.parameters_names, url_parameters_values))
 
     def __repr__(self) -> str:
         path = repr(self.path)
@@ -168,51 +171,3 @@ def as_route(
         return Route(path, methods, func, append_slash=append_slash)
 
     return route_decorator
-
-
-class _Routes:
-    """A collection of routes and their corresponding handlers."""
-
-    def __init__(self) -> None:
-        self._routes: List[Route] = []
-
-    def add(self, route: Route):
-        """Adds a route and its handler to the collection."""
-        self._routes.append(route)
-
-    def find_handler(self, route: Route) -> Union[Callable["...", "Response"], None]:
-        """
-        Finds a handler for a given route.
-
-        If route used URL parameters, the handler will be wrapped to pass the parameters to the
-        handler.
-
-        Example::
-
-            @server.route("/example/<my_parameter>", GET)
-            def route_func(request, my_parameter):
-                ...
-                request.path == "/example/123" # True
-                my_parameter == "123" # True
-        """
-        found_route, _route = False, None
-
-        for _route in self._routes:
-            matches, keyword_parameters = _route.match(route)
-
-            if matches:
-                found_route = True
-                break
-
-        if not found_route:
-            return None
-
-        handler = _route.handler
-
-        def wrapped_handler(request):
-            return handler(request, **keyword_parameters)
-
-        return wrapped_handler
-
-    def __repr__(self) -> str:
-        return f"_Routes({repr(self._routes)})"

--- a/adafruit_httpserver/route.py
+++ b/adafruit_httpserver/route.py
@@ -88,13 +88,14 @@ class Route:
         self, method: str, path: str
     ) -> Union[Tuple[Literal[False], None], Tuple[Literal[True], Dict[str, str]]]:
         """
-        Checks if the route matches the other route.
+        Checks if the route matches given ``method`` and ``path``.
 
-        If the route contains parameters, it will check if the ``other`` route contains values for
+        If the route contains parameters, it will check if the ``path`` contains values for
         them.
 
-        Returns tuple of a boolean and a list of strings. The boolean indicates if the routes match,
-        and the list contains the values of the url parameters from the ``other`` route.
+        Returns tuple of a boolean that indicates if the routes matches and a dict containing
+        values for url parameters.
+        If the route does not match ``path`` or ``method`` if will return ``None`` instead of dict.
 
         Examples::
 

--- a/adafruit_httpserver/route.py
+++ b/adafruit_httpserver/route.py
@@ -55,11 +55,23 @@ class Route:
         if not path.startswith("/"):
             raise ValueError("Path must start with a slash.")
 
+        if path.endswith("/") and append_slash:
+            raise ValueError("Cannot use append_slash=True when path ends with /")
+
+        if "//" in path:
+            raise ValueError("Path cannot contain double slashes.")
+
         if "<>" in path:
             raise ValueError("All URL parameters must be named.")
 
-        if path.endswith("/") and append_slash:
-            raise ValueError("Cannot use append_slash=True when path ends with /")
+        if re.search(r"[^/]<[^/]+>|<[^/]+>[^/]", path):
+            raise ValueError("All URL parameters must be between slashes.")
+
+        if re.search(r"[^/.]\.\.\.\.?|\.?\.\.\.[^/.]", path):
+            raise ValueError("... and .... must be between slashes")
+
+        if "....." in path:
+            raise ValueError("Path cannot contain more than 4 dots in a row.")
 
     def matches(
         self, method: str, path: str

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -234,32 +234,6 @@ class Server:  # pylint: disable=too-many-instance-attributes
         if self.debug:
             _debug_stopped_server(self)
 
-    def _receive_request(
-        self,
-        sock: Union["SocketPool.Socket", "socket.socket"],
-        client_address: Tuple[str, int],
-    ) -> Request:
-        """Receive bytes from socket until the whole request is received."""
-
-        # Receiving data until empty line
-        header_bytes = self._receive_header_bytes(sock)
-
-        # Return if no data received
-        if not header_bytes:
-            return None
-
-        request = Request(self, sock, client_address, header_bytes)
-
-        content_length = int(request.headers.get_directive("Content-Length", 0))
-        received_body_bytes = request.body
-
-        # Receiving remaining body bytes
-        request.body = self._receive_body_bytes(
-            sock, received_body_bytes, content_length
-        )
-
-        return request
-
     def _receive_header_bytes(
         self, sock: Union["SocketPool.Socket", "socket.socket"]
     ) -> bytes:
@@ -295,6 +269,32 @@ class Server:  # pylint: disable=too-many-instance-attributes
             except Exception as ex:
                 raise ex
         return received_body_bytes[:content_length]
+
+    def _receive_request(
+        self,
+        sock: Union["SocketPool.Socket", "socket.socket"],
+        client_address: Tuple[str, int],
+    ) -> Request:
+        """Receive bytes from socket until the whole request is received."""
+
+        # Receiving data until empty line
+        header_bytes = self._receive_header_bytes(sock)
+
+        # Return if no data received
+        if not header_bytes:
+            return None
+
+        request = Request(self, sock, client_address, header_bytes)
+
+        content_length = int(request.headers.get_directive("Content-Length", 0))
+        received_body_bytes = request.body
+
+        # Receiving remaining body bytes
+        request.body = self._receive_body_bytes(
+            sock, received_body_bytes, content_length
+        )
+
+        return request
 
     def _handle_request(
         self, request: Request, handler: Union[Callable, None]

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -295,7 +295,7 @@ class Server:  # pylint: disable=too-many-instance-attributes
 
         return request
 
-    def _find_handler(
+    def _find_handler(  # pylint: disable=cell-var-from-loop
         self, method: str, path: str
     ) -> Union[Callable[..., "Response"], None]:
         """

--- a/adafruit_httpserver/server.py
+++ b/adafruit_httpserver/server.py
@@ -171,7 +171,7 @@ class Server:  # pylint: disable=too-many-instance-attributes
             raise RuntimeError(f"Cannot start server on {host}:{port}") from error
 
     def serve_forever(
-        self, host: str, port: int = 80, *, poll_interval: float = None
+        self, host: str, port: int = 80, *, poll_interval: float = 0.1
     ) -> None:
         """
         Wait for HTTP requests at the given host and port. Does not return.
@@ -186,15 +186,13 @@ class Server:  # pylint: disable=too-many-instance-attributes
 
         while not self.stopped:
             try:
-                self.poll()
+                if self.poll() == NO_REQUEST and poll_interval is not None:
+                    sleep(poll_interval)
             except KeyboardInterrupt:  # Exit on Ctrl-C e.g. during development
                 self.stop()
                 return
             except Exception:  # pylint: disable=broad-except
                 pass  # Ignore exceptions in handler function
-
-            if poll_interval is not None:
-                sleep(poll_interval)
 
     def start(self, host: str, port: int = 80) -> None:
         """

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -5,7 +5,7 @@ Simple Test
 **This mode is useful for development, but it is not recommended to use it in production.**
 **More about Debug mode at the end of Examples section.**
 
-This is the minimal example of using the library.
+This is the minimal example of using the library with CircuitPython.
 This example is serving a simple static text message.
 
 It also manually connects to the WiFi network.
@@ -42,6 +42,17 @@ Note that we still need to import ``socketpool`` and ``wifi`` modules.
     :caption: examples/httpserver_simpletest_auto.py
     :emphasize-lines: 11
     :linenos:
+
+CPython usage
+--------------------
+
+Library can also be used in CPython, no changes other than changing the ``socket_source`` are necessary.
+
+.. literalinclude:: ../examples/httpserver_cpython.py
+    :caption: examples/httpserver_cpython.py
+    :emphasize-lines: 5,10
+    :linenos:
+
 
 Serving static files
 --------------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -58,11 +58,15 @@ In order to save memory, we are unregistering unused MIME types and registering 
     :linenos:
 
 You can also serve a specific file from the handler.
-By default ``FileResponse`` looks for the file in the server's ``root_path`` directory, but you can change it.
+By default ``FileResponse`` looks for the file in the server's ``root_path`` directory
+(``/default-static-directory`` in the example below), but you can change it manually in every ``FileResponse``
+(to e.g. ``/other-static-directory``, as in example below).
+
+By doing that, you can serve files from multiple directories, and decide exactly which files are accessible.
 
 .. literalinclude:: ../examples/httpserver_handler_serves_file.py
     :caption: examples/httpserver_handler_serves_file.py
-    :emphasize-lines: 22
+    :emphasize-lines: 13,22
     :linenos:
 
 .. literalinclude:: ../examples/home.html

--- a/examples/httpserver_cpython.py
+++ b/examples/httpserver_cpython.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024 Michał Pokusa
+#
+# SPDX-License-Identifier: Unlicense
+
+import socket
+
+from adafruit_httpserver import Server, Request, Response
+
+
+pool = socket
+server = Server(pool, "/static", debug=True)
+
+
+@server.route("/")
+def base(request: Request):
+    """
+    Serve a default static plain text message.
+    """
+    return Response(request, "Hello from the CircuitPython HTTP Server!")
+
+
+server.serve_forever("0.0.0.0")

--- a/examples/httpserver_handler_serves_file.py
+++ b/examples/httpserver_handler_serves_file.py
@@ -10,16 +10,16 @@ from adafruit_httpserver import Server, Request, FileResponse
 
 
 pool = socketpool.SocketPool(wifi.radio)
-server = Server(pool, "/static", debug=True)
+server = Server(pool, "/default-static-folder", debug=True)
 
 
 @server.route("/home")
 def home(request: Request):
     """
-    Serves the file /www/home.html.
+    Serves the file /other-static-folder/home.html.
     """
 
-    return FileResponse(request, "home.html", "/www")
+    return FileResponse(request, "home.html", "/other-static-folder")
 
 
 server.serve_forever(str(wifi.radio.ipv4_address))


### PR DESCRIPTION
This is a somewhat of a minor change, that does not affect users as it does not change the library's API.
While making on of my projects I noticed that on each request multiple `Route` objects are created and multiple `re` methods are called.

This PR changes the way `Server` handles it's routes. New method is more efficient and has some fixes compared to the current way.

⭐ Added:

- Additinal validation to `path` in `Route` constructor
- EDIT1: Example of using `adafruit_httpserver` with CPython (resolves #77)

🗑️ Deleted:

- `_Routes` class as it is no longer needed

🪛Fixes:

- Literal dots in paths now behave correctly, before they matched every character
- Before `...` and `....` could be used in other places than between slashes, now the error is raised when trying to do so
  
🛠️ Updated/Changed:

- `Route` now has separate `path` and `path_pattern`, the later one is created using separate method for better readability
- `Route.matches` had docs with typos, after the change docs were updated so it is no longer the case
- EDIT1: `Server.serve_forever` defaults `poll_interval` to 0.1s and catches `KeyboardInterrupt`s during sleeping, it also sleeps only if no request were processed, so it will not affect performance during bursts

🏗️ Refactor:

- Now it is the `Server`'s responsibility to find a matching `Route`
- Only `method` and `path` is passed when finding a matching `Route`, this way we are not creating multiple unnecessary `Route` objects on every request
- Example that shows manual static files handling is now more verbose, which resolves #75