### PR TITLE
Add httpserver simpletest with connection manager

### DIFF
--- a/examples/httpserver_simpletest_connectionmanager.py
+++ b/examples/httpserver_simpletest_connectionmanager.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2024 DJDevon3
+# SPDX-License-Identifier: MIT
+# Coded for Circuit Python 9.
+"""HTTP Server Simpletest with Connection Manager"""
+# pylint: disable=import-error
+
+import os
+
+import adafruit_connection_manager
+import wifi
+
+from adafruit_httpserver import Server, Request, Response
+
+# Get WiFi details, ensure these are setup in settings.toml
+ssid = os.getenv("CIRCUITPY_WIFI_SSID")
+password = os.getenv("CIRCUITPY_WIFI_PASSWORD")
+
+print("Connecting to WiFi...")
+wifi.radio.connect(ssid, password)
+print("✅ Wifi!")
+
+# Initalize Wifi, Socket Pool, Request Session
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+server = Server(pool, "/static", debug=True)
+
+
+@server.route("/")
+def base(request: Request):
+    """Serve a default static plain text message"""
+    return Response(request, "Hello from the CircuitPython HTTP Server!")
+
+
+server.serve_forever(str(wifi.radio.ipv4_address))

--- a/examples/httpserver_simpletest_connectionmanager.py
+++ b/examples/httpserver_simpletest_connectionmanager.py
@@ -12,8 +12,8 @@ import wifi
 from adafruit_httpserver import Server, Request, Response
 
 # Get WiFi details, ensure these are setup in settings.toml
-ssid = os.getenv("CIRCUITPY_WIFI_SSID")
-password = os.getenv("CIRCUITPY_WIFI_PASSWORD")
+ssid = os.getenv("WIFI_SSID")
+password = os.getenv("WIFI_PASSWORD")
 
 print("Connecting to WiFi...")
 wifi.radio.connect(ssid, password)
@@ -21,7 +21,6 @@ print("✅ Wifi!")
 
 # Initalize Wifi, Socket Pool, Request Session
 pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
-ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
 server = Server(pool, "/static", debug=True)
 
 


### PR DESCRIPTION
Only handles setup for socketpool. Coming from requests examples I'm more used to seeing connection manager handle the pool now. It might be good for consistency to role out connection manager for all examples but I'll leave that up to you.  It will be nice to at least have 1 example that uses Connection Manager in there.