### PR TITLE
Update Ethernet library usage

### DIFF
--- a/docs/starting_methods.rst
+++ b/docs/starting_methods.rst
@@ -28,13 +28,11 @@ it may not be able to access the internet.
 Manual Ethernet
 ---------------
 
-Most of the time, the WiFi will be a preferred way of connecting to the network.
-Nevertheless it is also possible to use Ethernet instead of WiFi.
-The only difference in usage is related to configuring the ``socket_source`` differently.
+Ethernet can also be used to connect to the location network.
 
 .. literalinclude:: ../examples/httpserver_simpletest_manual_ethernet.py
     :caption: examples/httpserver_simpletest_manual_ethernet.py
-    :emphasize-lines: 7,10,12-24,37
+    :emphasize-lines: 11-20
     :linenos:
 
 Automatic WiFi using ``settings.toml``

--- a/examples/httpserver_simpletest_manual_ethernet.py
+++ b/examples/httpserver_simpletest_manual_ethernet.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+import adafruit_connection_manager
 import board
 import digitalio
-from adafruit_wiznet5k import adafruit_wiznet5k_socket as socket
 from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 
 from adafruit_httpserver import Request, Response, Server
@@ -20,10 +20,9 @@ spi_bus = board.SPI()
 # Initialize ethernet interface with DHCP
 eth = WIZNET5K(spi_bus, cs)
 
-# Set the interface on the socket source
-socket.set_interface(eth)
+pool = adafruit_connection_manager.get_radio_socketpool(eth)
 
-server = Server(socket, "/static", debug=True)
+server = Server(pool, "/static", debug=True)
 
 
 @server.route("/")


### PR DESCRIPTION
- Use `adafruit_connection_manager`.
- Remove obsolete use of `adafruit_wiznet5k_socket`.

Tested as part of testing #103.